### PR TITLE
add "vagrant seil-save-to-host" command

### DIFF
--- a/lib/vagrant-seil/command.rb
+++ b/lib/vagrant-seil/command.rb
@@ -1,0 +1,64 @@
+require "optparse"
+require "vagrant"
+
+module VagrantPlugins
+  module Seil
+    class Command < Vagrant.plugin(2, :command)
+      def self.synopsis
+        "save configuration of running SEIL into specified host file"
+      end
+
+      def execute
+        options = {}
+
+        opts = OptionParser.new do |o|
+          o.banner = "Usage: vagrant seil-save-to [options] [name]"
+          o.separator ""
+          o.separator "Options:"
+          o.separator ""
+
+          o.on("-o", "--output FILENAME", "Save a SEIL configuration in specified file") do |v|
+            options[:output] = v
+          end
+        end
+
+        argv = parse_options(opts)
+
+        with_target_vms(argv, simgle_target: true) do |vm|
+          if options[:output] == nil
+            vm.ui.warn I18n.t("vagrant_seil.save_to_failed")
+            return
+          end
+
+          lines = ""
+          vm.communicate.tap do |comm|
+            comm.execute("show config") do |type, text|
+              lines += text
+            end
+          end
+
+          begin
+            File.open(options[:output], "w") do |f|
+              lines.split("\r\n").each do |line|
+                # remove unnecessary lines
+                case line
+                when /^success$/
+                  next
+                when /^exit\(\d+\)\.$/
+                  next
+                end
+
+                f.puts(line)
+              end
+            end
+          rescue
+            vm.ui.warn I18n.t("vagrant_seil.save_to_failed")
+            return
+          end
+
+          return 0
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-seil/command.rb
+++ b/lib/vagrant-seil/command.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
         options = {}
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant seil-save-to [options] [name]"
+          o.banner = "Usage: vagrant seil-save-to-host [options] [name]"
           o.separator ""
           o.separator "Options:"
           o.separator ""

--- a/lib/vagrant-seil/plugin.rb
+++ b/lib/vagrant-seil/plugin.rb
@@ -27,6 +27,11 @@ module VagrantPlugins
         Config
       end
 
+      command :'seil-save-to-host' do
+        require_relative "command"
+        Command
+      end
+
       provisioner "seil" do
         setup_i18n
         #setup_logging

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,3 +8,5 @@ en:
       Warning: configuration is not saved because function key is not installed.
     save_to_flashrom: |-
       save-to flashrom...
+    save_to_failed: |-
+      Warning: vagrant-seil failed to save configuration into host file


### PR DESCRIPTION
Added command that saves configuration of running SEIL into specified host file.
This would prevent us from checking & updating consistency between Vagrantfile and "show config".

Following is an example of command lines that saves "show config" result into "output.cfg".

```
% vagrant seil-save-to-host default -o output.cfg
```
